### PR TITLE
Style edits

### DIFF
--- a/src/CoxPH.hs
+++ b/src/CoxPH.hs
@@ -90,22 +90,23 @@ updateStep :: Int -> Double -> Int -> VS.Vector Double -> VS.Vector Double -> Do
 updateStep maxIterations epsilon iteration beta xOffset logLikelihood tteData
     | iteration > maxIterations =
         Left "Did not converge in the alloted number of iterations"
-    | otherwise = calcBetaOffset tteData >>= \(betaOffset, nrResults) ->
-                let newBeta = L.add beta betaOffset
-                 in if checkNRConvergence epsilon logLikelihood nrResults
-                        then -- Case: we've achieved convergence;
-                            Right newBeta
-                        else -- Case: we haven't achieved convergence yet, but the log
-                             -- likelihood is moving in the right direction
+    | otherwise =
+        calcBetaOffset tteData >>= \(betaOffset, nrResults) ->
+            let newBeta = L.add beta betaOffset
+             in if checkNRConvergence epsilon logLikelihood nrResults
+                    then -- Case: we've achieved convergence;
+                        Right newBeta
+                    else -- Case: we haven't achieved convergence yet, but the log
+                    -- likelihood is moving in the right direction
 
-                            updateStep
-                                maxIterations
-                                epsilon
-                                (iteration + 1)
-                                newBeta
-                                xOffset
-                                nrResults.sumLogLikelihood
-                                (updateTTEData newBeta xOffset tteData)
+                        updateStep
+                            maxIterations
+                            epsilon
+                            (iteration + 1)
+                            newBeta
+                            xOffset
+                            nrResults.sumLogLikelihood
+                            (updateTTEData newBeta xOffset tteData)
 
 updateTTEData :: VS.Vector Double -> VS.Vector Double -> TTEData -> TTEData
 updateTTEData beta xOffset tteData =

--- a/src/CoxPH.hs
+++ b/src/CoxPH.hs
@@ -90,10 +90,7 @@ updateStep :: Int -> Double -> Int -> VS.Vector Double -> VS.Vector Double -> Do
 updateStep maxIterations epsilon iteration beta xOffset logLikelihood tteData
     | iteration > maxIterations =
         Left "Did not converge in the alloted number of iterations"
-    | otherwise =
-        case calcBetaOffset tteData of
-            Left e -> Left e
-            Right (betaOffset, nrResults) ->
+    | otherwise = calcBetaOffset tteData >>= \(betaOffset, nrResults) ->
                 let newBeta = L.add beta betaOffset
                  in if checkNRConvergence epsilon logLikelihood nrResults
                         then -- Case: we've achieved convergence;

--- a/src/CoxPH.hs
+++ b/src/CoxPH.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE MultiWayIf #-}
-
 module CoxPH (
     CoxPHConvergenceFailure (..),
     CoxPHMethod (..),
@@ -97,15 +95,12 @@ updateStep maxIterations epsilon iteration beta xOffset logLikelihood tteData
             Left e -> Left e
             Right (betaOffset, nrResults) ->
                 let newBeta = L.add beta betaOffset
-                 in if
-                        | checkNRConvergence epsilon logLikelihood nrResults ->
+                 in if checkNRConvergence epsilon logLikelihood nrResults
+                        then -- Case: we've achieved convergence;
                             Right newBeta
-                        -- Case: the logLikelihood is moving in the wrong direction
-                        -- \| checkDecreasingLogLikelihood logLikelihood nrResults ->
-                        --   Left "Likelihood not nondecreasing"
-                        -- -- Case: we haven't achieved convergence yet, but the log
-                        -- -- likelihood is moving in the right direction
-                        | otherwise ->
+                        else -- Case: we haven't achieved convergence yet, but the log
+                             -- likelihood is moving in the right direction
+
                             updateStep
                                 maxIterations
                                 epsilon

--- a/src/CoxPH.hs
+++ b/src/CoxPH.hs
@@ -1,123 +1,137 @@
 {-# LANGUAGE MultiWayIf #-}
 
 module CoxPH (
-  CoxPHConvergenceFailure(..),
-  CoxPHMethod(..),
-  Delta(..),
-  LastInStrataIndicator(..),
-  ScaleCovariateIndicator(..),
-  coxph
-  ) where
+    CoxPHConvergenceFailure (..),
+    CoxPHMethod (..),
+    Delta (..),
+    LastInStrataIndicator (..),
+    ScaleCovariateIndicator (..),
+    coxph,
+) where
 
 import CoxPH.CenterAndScale (centerAndScaleCovs)
-import CoxPH.CoxPHUpdateNewtonRaphson ( NRResults(..), TTEData(..), coxPHUpdateNewtonRaphson )
+import CoxPH.CoxPHUpdateNewtonRaphson (NRResults (..), TTEData (..), coxPHUpdateNewtonRaphson)
 import CoxPH.Data
 import Data.Text qualified as T
 import Data.Vector qualified as V
 import Data.Vector.Storable qualified as VS
 import Numeric.LinearAlgebra qualified as L
 
--- -- type CoxPHResult = Either CoxPHConvergenceFailure (VU.Vector Double)
--- type CoxPHResult = Either T.Text (VS.Vector Double)
-
-coxph :: VS.Vector Double                  -- length n, the per-subject minumum times of the event or censoring times
-      -> V.Vector Delta                    -- length n, indicators for whether patient observered an event or censoring
-      -> V.Vector (VS.Vector Double)       -- dimension n by p, X design matrix
-      -> VS.Vector Double                  -- length n, X offset vector
-      -> VS.Vector Double                  -- length n, subject weights
-      -> VS.Vector Int                     -- length n, strata
-      -> VS.Vector Double                  -- length p, starting values for the beta coefficients
-      -> V.Vector ScaleCovariateIndicator  -- length p, indicators for whether a given covariate should be centered and scaled
-      -> CoxPHMethod                       -- which of the Breslow or Effron methods to use in the event of tied event times
-      -> Int                               -- the maximumn number of Newton-Rhapson iterations to perform
-      -> Double                            -- the value for which the absolute value of 1 minus ratio of the likelihood for two consecutive iterations must be below for convergence to be achieved
-      -- -> Double                            -- TODO
-      -> Either T.Text (VS.Vector Double)
-coxph times
-      eventStatuses
-      xDesignDataFrame
-      xOffset
-      weights
-      strata
-      beta
-      scaleIndicators
-      tiesMethod
-      maxIterations
-      epsilon
-      -- tolerance
-      = do
-  -- in Right (VS.fromList [])
-  centeredAndScaledCovsResults <- centerAndScaleCovs xDesignDataFrame
-                                                     weights
-                                                     scaleIndicators
-  let (centeredAndScaledCovs, scales) = V.unzip centeredAndScaledCovsResults
-      -- scales = V.map snd centeredAndScaledCovsResults
-      xDesignMatrix = L.fromColumns (V.toList centeredAndScaledCovs)
-      tteData = TTEData
-        { time = times
-        , eventStatus = eventStatuses
-        , xDesignMatrix = xDesignMatrix
-        , stratum = strata
-        , weights = weights
-        , xProdBeta = L.add xOffset (xDesignMatrix L.#> beta)
-        , tiesMethod = tiesMethod
-        }
-  (betaOffset, nrResults) <- calcBetaOffset tteData
-  let newBeta = L.add beta betaOffset
-  finalBeta <- updateStep maxIterations
-                          epsilon
-                          2 -- since we've manually done one iteration so far
-                          newBeta
-                          xOffset
-                          nrResults.sumLogLikelihood
-                          (updateTTEData newBeta xOffset tteData)
-  Right (VS.convert scales / finalBeta)
+-- | TODO:
+coxph ::
+    -- | length n, the per-subject minumum times of the event or censoring times
+    VS.Vector Double ->
+    -- | length n, indicators for whether patient observered an event or censoring
+    V.Vector Delta ->
+    -- | dimension n by p, X design matrix
+    V.Vector (VS.Vector Double) ->
+    -- | length n, X offset vector
+    VS.Vector Double ->
+    -- | length n, subject weights
+    VS.Vector Double ->
+    -- | length n, strata
+    VS.Vector Int ->
+    -- | length p, starting values for the beta coefficients
+    VS.Vector Double ->
+    -- | length p, indicators for whether a given covariate should be centered and scaled
+    V.Vector ScaleCovariateIndicator ->
+    -- | which of the Breslow or Effron methods to use in the event of tied event times
+    CoxPHMethod ->
+    -- | the maximum number of Newton-Rhapson iterations to perform
+    Int ->
+    -- | the value for which the absolute value of 1 minus ratio of the likelihood for two consecutive iterations must be below for convergence to be achieved
+    -- -> Double                            -- TODO
+    Double ->
+    Either T.Text (VS.Vector Double)
+coxph
+    times
+    eventStatuses
+    xDesignDataFrame
+    xOffset
+    weights
+    strata
+    beta
+    scaleIndicators
+    tiesMethod
+    maxIterations
+    epsilon =
+        -- tolerance
+        do
+            centeredAndScaledCovsResults <-
+                centerAndScaleCovs
+                    xDesignDataFrame
+                    weights
+                    scaleIndicators
+            let (centeredAndScaledCovs, scales) = V.unzip centeredAndScaledCovsResults
+                -- scales = V.map snd centeredAndScaledCovsResults
+                xDesignMatrix = L.fromColumns (V.toList centeredAndScaledCovs)
+                tteData =
+                    TTEData
+                        { time = times
+                        , eventStatus = eventStatuses
+                        , xDesignMatrix = xDesignMatrix
+                        , stratum = strata
+                        , weights = weights
+                        , xProdBeta = L.add xOffset (xDesignMatrix L.#> beta)
+                        , tiesMethod = tiesMethod
+                        }
+            (betaOffset, nrResults) <- calcBetaOffset tteData
+            let newBeta = L.add beta betaOffset
+            finalBeta <-
+                updateStep
+                    maxIterations
+                    epsilon
+                    2 -- since we've manually done one iteration so far
+                    newBeta
+                    xOffset
+                    nrResults.sumLogLikelihood
+                    (updateTTEData newBeta xOffset tteData)
+            Right (VS.convert scales / finalBeta)
 
 updateStep :: Int -> Double -> Int -> VS.Vector Double -> VS.Vector Double -> Double -> TTEData -> Either T.Text (VS.Vector Double)
 updateStep maxIterations epsilon iteration beta xOffset logLikelihood tteData
-  | iteration > maxIterations =
-    Left "Did not converge in the alloted number of iterations"
-  | otherwise =
-    case calcBetaOffset tteData of
-      Left e -> Left e
-      Right (betaOffset, nrResults) ->
-        let newBeta = L.add beta betaOffset
-        in  if -- Case: we've achieved convergence;
-               | checkNRConvergence epsilon logLikelihood nrResults ->
-                 Right newBeta
-               -- Case: the logLikelihood is moving in the wrong direction
-               -- | checkDecreasingLogLikelihood logLikelihood nrResults ->
-               --   Left "Likelihood not nondecreasing"
-               -- -- Case: we haven't achieved convergence yet, but the log
-               -- -- likelihood is moving in the right direction
-               | otherwise ->
-                 updateStep maxIterations
-                            epsilon
-                            (iteration + 1)
-                            newBeta
-                            xOffset
-                            nrResults.sumLogLikelihood
-                            (updateTTEData newBeta xOffset tteData)
+    | iteration > maxIterations =
+        Left "Did not converge in the alloted number of iterations"
+    | otherwise =
+        case calcBetaOffset tteData of
+            Left e -> Left e
+            Right (betaOffset, nrResults) ->
+                let newBeta = L.add beta betaOffset
+                 in if
+                        | checkNRConvergence epsilon logLikelihood nrResults ->
+                            Right newBeta
+                        -- Case: the logLikelihood is moving in the wrong direction
+                        -- \| checkDecreasingLogLikelihood logLikelihood nrResults ->
+                        --   Left "Likelihood not nondecreasing"
+                        -- -- Case: we haven't achieved convergence yet, but the log
+                        -- -- likelihood is moving in the right direction
+                        | otherwise ->
+                            updateStep
+                                maxIterations
+                                epsilon
+                                (iteration + 1)
+                                newBeta
+                                xOffset
+                                nrResults.sumLogLikelihood
+                                (updateTTEData newBeta xOffset tteData)
 
 updateTTEData :: VS.Vector Double -> VS.Vector Double -> TTEData -> TTEData
 updateTTEData beta xOffset tteData =
-  let newXProdBeta = L.add xOffset
-                           (tteData.xDesignMatrix L.#> beta)
-  in  tteData { xProdBeta = newXProdBeta }
+    let newXProdBeta =
+            L.add
+                xOffset
+                (tteData.xDesignMatrix L.#> beta)
+     in tteData{xProdBeta = newXProdBeta}
 
 -- calculates I^{-1}(\hat{\beta}^{(n)})\, U(\hat{\beta}^{(n)}), i.e. the term
 -- that we add to \hat{\beta}^{(n)} to update it
 calcBetaOffset :: TTEData -> Either T.Text (VS.Vector Double, NRResults)
 calcBetaOffset tteData = do
-  let nrResults = coxPHUpdateNewtonRaphson tteData
-      inverseInformationMatrix = L.inv nrResults.informationMatrix  -- FIXME: this can fail. Need to catch failure as appropriate
-      betaOffset = inverseInformationMatrix L.#> nrResults.score
-  Right (betaOffset, nrResults)
+    let nrResults = coxPHUpdateNewtonRaphson tteData
+        inverseInformationMatrix = L.inv nrResults.informationMatrix -- FIXME: this can fail. Need to catch failure as appropriate
+        betaOffset = inverseInformationMatrix L.#> nrResults.score
+    Right (betaOffset, nrResults)
 
 checkNRConvergence :: Double -> Double -> NRResults -> Bool
 checkNRConvergence epsilon logLikelihood nrResults =
-  abs (1 - (logLikelihood / nrResults.sumLogLikelihood)) < epsilon
-
-checkDecreasingLogLikelihood :: Double -> NRResults -> Bool
-checkDecreasingLogLikelihood logLikelihood nrResults =
-  logLikelihood >= nrResults.sumLogLikelihood
+    abs (1 - (logLikelihood / nrResults.sumLogLikelihood)) < epsilon

--- a/src/CoxPH/CenterAndScale.hs
+++ b/src/CoxPH/CenterAndScale.hs
@@ -37,10 +37,8 @@ centerAndScaleCovs xDesignMatrix weights scaleIndicators =
                             (V.convert weightedMeans)
                             (V.replicate nCovs sumWeights)
                             scaleIndicators
-                    eitherResults = V.map conditionallyCenterAndScaleCov covTuples
-                if V.any isLeft eitherResults
-                    then Left "Not all covariates where able to be centered and scaled"
-                    else Right $ V.map (fromRight (VS.singleton 0, 0)) eitherResults
+
+                traverse conditionallyCenterAndScaleCov covTuples
   where
     conditionallyCenterAndScaleCov (x, _, _, _, ScaleCovariateNo) =
         Right (x, 1)

--- a/src/CoxPH/CenterAndScale.hs
+++ b/src/CoxPH/CenterAndScale.hs
@@ -101,7 +101,7 @@ calcWeightedMean x weights sumWeights
     | VS.length x == 0 = Left "Can't take the mean of a length-0 vector"
     | sumWeights == 0 = Left "Can't take the mean when the weights sum to 0"
     | otherwise =
-        let sumCovs = VU.foldl op 0 (VU.zip (VU.convert x) (VU.convert weights))
+        let sumCovs = VU.foldl' op 0 (VU.zip (VU.convert x) (VU.convert weights))
          in Right (sumCovs / sumWeights)
   where
     op :: Double -> (Double, Double) -> Double

--- a/src/CoxPH/CenterAndScale.hs
+++ b/src/CoxPH/CenterAndScale.hs
@@ -62,7 +62,7 @@ centerAndScaleCov x weights mean sumWeights
     | otherwise =
         let xCentered = VS.map (subtract mean) x
             covariatePairs = VU.zip (VU.convert xCentered) (VU.convert weights)
-            weightedAbsCovSum = VU.foldl calcAbsProd 0 covariatePairs
+            weightedAbsCovSum = VU.foldl' calcAbsProd 0 covariatePairs
          in if weightedAbsCovSum == 0
                 then Left "Constant column"
                 else

--- a/src/CoxPH/CenterAndScale.hs
+++ b/src/CoxPH/CenterAndScale.hs
@@ -5,7 +5,6 @@ module CoxPH.CenterAndScale (
 ) where
 
 import CoxPH.Data
-import Data.Either (fromRight, isLeft)
 import Data.Text qualified as T
 import Data.Vector qualified as V
 import Data.Vector.Storable qualified as VS

--- a/src/CoxPH/CenterAndScale.hs
+++ b/src/CoxPH/CenterAndScale.hs
@@ -1,114 +1,123 @@
 {-# OPTIONS_GHC -Wno-name-shadowing #-}
 
 module CoxPH.CenterAndScale (
-  centerAndScaleCovs
-  ) where
+    centerAndScaleCovs,
+) where
 
 import CoxPH.Data
+import Data.Either (fromRight, isLeft)
+import Data.Text qualified as T
+import Data.Vector qualified as V
 import Data.Vector.Storable qualified as VS
 import Data.Vector.Unboxed qualified as VU
-import Data.Vector qualified as V
-import Data.Text qualified as T
-import Data.Either (fromRight, isLeft)
 
-{- | Conditionally center and scale a design matrix
--}
-centerAndScaleCovs :: V.Vector (VS.Vector Double)
-                   -- ^ The covariate vectors comprising the design matrix. The covariate vectors are required to all be the same length.
-                   -> VS.Vector Double
-                   -- ^ The subject weights. It is required that the length of this vector is equal to the length of each of the vectors in the design matrix.
-                   -> V.Vector ScaleCovariateIndicator
-                   -- ^ Indicators for whether each of the covariates should be centered and scaled. It is required that the length of this vector is equal to the number of vectors in the design matrix.
-                   -> Either T.Text (V.Vector (VS.Vector Double, Double))
+-- | Conditionally center and scale a design matrix
+centerAndScaleCovs ::
+    -- | The covariate vectors comprising the design matrix. The covariate vectors are required to all be the same length.
+    V.Vector (VS.Vector Double) ->
+    -- | The subject weights. It is required that the length of this vector is equal to the length of each of the vectors in the design matrix.
+    VS.Vector Double ->
+    -- | Indicators for whether each of the covariates should be centered and scaled. It is required that the length of this vector is equal to the number of vectors in the design matrix.
+    V.Vector ScaleCovariateIndicator ->
+    Either T.Text (V.Vector (VS.Vector Double, Double))
 -- The error handling could be improved to (i) list all of the errors and (ii)
 -- to list the indices of the failing vectors
 centerAndScaleCovs xDesignMatrix weights scaleIndicators =
-  let nCovs = V.length xDesignMatrix
-      nScaleIndicators = V.length scaleIndicators
-      sumWeights = VS.sum weights
-  in if nCovs /= nScaleIndicators
-     then Left "The length of first input is not the same as the length of the third input"
-     else do
-       weightedMeans <- calcWeightedMeans sumWeights xDesignMatrix weights scaleIndicators
-       let covTuples = V.zip5 xDesignMatrix
-                              (V.replicate nCovs weights)
-                              (V.convert weightedMeans)
-                              (V.replicate nCovs sumWeights)
-                              scaleIndicators
-           eitherResults = V.map conditionallyCenterAndScaleCov covTuples
-       if V.any isLeft eitherResults
-       then Left "Not all covariates where able to be centered and scaled"
-       else Right $ V.map (fromRight (VS.singleton 0, 0)) eitherResults
+    let nCovs = V.length xDesignMatrix
+        nScaleIndicators = V.length scaleIndicators
+        sumWeights = VS.sum weights
+     in if nCovs /= nScaleIndicators
+            then Left "The length of first input is not the same as the length of the third input"
+            else do
+                weightedMeans <- calcWeightedMeans sumWeights xDesignMatrix weights scaleIndicators
+                let covTuples =
+                        V.zip5
+                            xDesignMatrix
+                            (V.replicate nCovs weights)
+                            (V.convert weightedMeans)
+                            (V.replicate nCovs sumWeights)
+                            scaleIndicators
+                    eitherResults = V.map conditionallyCenterAndScaleCov covTuples
+                if V.any isLeft eitherResults
+                    then Left "Not all covariates where able to be centered and scaled"
+                    else Right $ V.map (fromRight (VS.singleton 0, 0)) eitherResults
   where
     conditionallyCenterAndScaleCov (x, _, _, _, ScaleCovariateNo) =
-      Right (x, 1)
+        Right (x, 1)
     conditionallyCenterAndScaleCov (x, weights, mean, sumWeights, ScaleCovariateYes) =
-      centerAndScaleCov x weights mean sumWeights
+        centerAndScaleCov x weights mean sumWeights
 
-centerAndScaleCov :: VS.Vector Double
-                  -> VS.Vector Double
-                  -> Double
-                  -> Double
-                  -> Either T.Text (VS.Vector Double, Double)
+centerAndScaleCov ::
+    VS.Vector Double ->
+    VS.Vector Double ->
+    Double ->
+    Double ->
+    Either T.Text (VS.Vector Double, Double)
 centerAndScaleCov x weights mean sumWeights
-  | VS.length x /= VS.length weights =
-      Left $ T.concat [ "The length of the first input (the covariate values) "
-                      , "is not the same as the length of the second input "
-                      , "(the weights)"
-                      ]
-  | otherwise =
-      let xCentered = VS.map (subtract mean) x
-          covariatePairs = VU.zip (VU.convert xCentered) (VU.convert weights)
-          weightedAbsCovSum = VU.foldl calcAbsProd 0 covariatePairs
-      in  if weightedAbsCovSum == 0
-          then Left "Constant column"
-          else let scaleVal = sumWeights / weightedAbsCovSum
-               in  Right (VS.map (* scaleVal) xCentered, scaleVal)
+    | VS.length x /= VS.length weights =
+        Left $
+            T.concat
+                [ "The length of the first input (the covariate values) "
+                , "is not the same as the length of the second input "
+                , "(the weights)"
+                ]
+    | otherwise =
+        let xCentered = VS.map (subtract mean) x
+            covariatePairs = VU.zip (VU.convert xCentered) (VU.convert weights)
+            weightedAbsCovSum = VU.foldl calcAbsProd 0 covariatePairs
+         in if weightedAbsCovSum == 0
+                then Left "Constant column"
+                else
+                    let scaleVal = sumWeights / weightedAbsCovSum
+                     in Right (VS.map (* scaleVal) xCentered, scaleVal)
   where
     calcAbsProd :: Double -> (Double, Double) -> Double
     calcAbsProd sumVal (xVal, weightVal) = sumVal + abs (xVal * weightVal)
 
 -- The error handling could be improved to (i) list all of the errors and (ii)
 -- to list the indices of the failing vectors
-calcWeightedMeans :: Double
-                  -> V.Vector (VS.Vector Double)
-                  -> VS.Vector Double
-                  -> V.Vector ScaleCovariateIndicator
-                  -> Either T.Text (VS.Vector Double)
+calcWeightedMeans ::
+    Double ->
+    V.Vector (VS.Vector Double) ->
+    VS.Vector Double ->
+    V.Vector ScaleCovariateIndicator ->
+    Either T.Text (VS.Vector Double)
 calcWeightedMeans sumWeights xDesignMatrix weights scaleIndicators = do
-  let covariatePairs = V.zip xDesignMatrix scaleIndicators
-      eitherMeans = V.map (conditionallyCalcWeightedMean weights)
-                             covariatePairs
-      errorCovs = V.filter isLeft eitherMeans
-  if V.length errorCovs >= 1
-  then
-    -- The conditional statement makes the `Right` case unreachable
-    case V.head errorCovs of
-      Left x -> Left x
-      Right x -> Right (VS.singleton x)
-  else Right (VS.convert (V.map (fromRight 0) eitherMeans))
+    let covariatePairs = V.zip xDesignMatrix scaleIndicators
+        eitherMeans =
+            V.map
+                (conditionallyCalcWeightedMean weights)
+                covariatePairs
+        errorCovs = V.filter isLeft eitherMeans
+    if V.length errorCovs >= 1
+        then -- The conditional statement makes the `Right` case unreachable
+        case V.head errorCovs of
+            Left x -> Left x
+            Right x -> Right (VS.singleton x)
+        else Right (VS.convert (V.map (fromRight 0) eitherMeans))
   where
-    conditionallyCalcWeightedMean :: VS.Vector Double
-                                  -> (VS.Vector Double, ScaleCovariateIndicator)
-                                  -> Either T.Text Double
+    conditionallyCalcWeightedMean ::
+        VS.Vector Double ->
+        (VS.Vector Double, ScaleCovariateIndicator) ->
+        Either T.Text Double
     conditionallyCalcWeightedMean _ (_, ScaleCovariateNo) = Right 0
     conditionallyCalcWeightedMean weights (x, ScaleCovariateYes) =
-      calcWeightedMean x weights sumWeights
+        calcWeightedMean x weights sumWeights
 
-calcWeightedMean :: VS.Vector Double
-                 -> VS.Vector Double
-                 -> Double
-                 -> Either T.Text Double
+calcWeightedMean ::
+    VS.Vector Double ->
+    VS.Vector Double ->
+    Double ->
+    Either T.Text Double
 calcWeightedMean x weights sumWeights
-  | VS.length x == 0 = Left "Can't take the mean of a length-0 vector"
-  | sumWeights == 0 = Left "Can't take the mean when the weights sum to 0"
-  | otherwise =
-    let sumCovs = VU.foldl op 0 (VU.zip (VU.convert x) (VU.convert weights))
-    in  Right (sumCovs / sumWeights)
+    | VS.length x == 0 = Left "Can't take the mean of a length-0 vector"
+    | sumWeights == 0 = Left "Can't take the mean when the weights sum to 0"
+    | otherwise =
+        let sumCovs = VU.foldl op 0 (VU.zip (VU.convert x) (VU.convert weights))
+         in Right (sumCovs / sumWeights)
   where
     op :: Double -> (Double, Double) -> Double
     op sumCovs (covVal, weightVal) = sumCovs + covVal * weightVal
-
 
 -- -- Possibly don't need ---------------------------------------------------------
 

--- a/src/CoxPH/CenterAndScale.hs
+++ b/src/CoxPH/CenterAndScale.hs
@@ -80,19 +80,9 @@ calcWeightedMeans ::
     VS.Vector Double ->
     V.Vector ScaleCovariateIndicator ->
     Either T.Text (VS.Vector Double)
-calcWeightedMeans sumWeights xDesignMatrix weights scaleIndicators = do
-    let covariatePairs = V.zip xDesignMatrix scaleIndicators
-        eitherMeans =
-            V.map
-                (conditionallyCalcWeightedMean weights)
-                covariatePairs
-        errorCovs = V.filter isLeft eitherMeans
-    if V.length errorCovs >= 1
-        then -- The conditional statement makes the `Right` case unreachable
-        case V.head errorCovs of
-            Left x -> Left x
-            Right x -> Right (VS.singleton x)
-        else Right (VS.convert (V.map (fromRight 0) eitherMeans))
+calcWeightedMeans sumWeights xDesignMatrix weights scaleIndicators =
+    fmap VS.convert . traverse (conditionallyCalcWeightedMean weights) $
+        V.zip xDesignMatrix scaleIndicators
   where
     conditionallyCalcWeightedMean ::
         VS.Vector Double ->

--- a/src/CoxPH/CoxPHUpdateNewtonRaphson.hs
+++ b/src/CoxPH/CoxPHUpdateNewtonRaphson.hs
@@ -1,299 +1,341 @@
 {-# LANGUAGE DuplicateRecordFields #-}
 {-# OPTIONS_GHC -Wno-name-shadowing #-}
--- |
 
 module CoxPH.CoxPHUpdateNewtonRaphson where
 
 import CoxPH.Data
-import Numeric.LinearAlgebra ( Matrix, add, cols, diag, outer, scale )
-import Numeric.LinearAlgebra.Data qualified as LD
-import Data.Vector.Storable qualified as VS
 import Data.Vector qualified as V
+import Data.Vector.Storable qualified as VS
+import Numeric.LinearAlgebra (Matrix, add, cols, diag, outer, scale)
+import Numeric.LinearAlgebra.Data qualified as LD
 
 data IterationInfo = IterationInfo
-  { subjectIndex :: Int
-  , time :: Double
-  , stratum :: Int
-  , nEvents :: Int
-  }
-  deriving Show
+    { subjectIndex :: Int
+    , time :: Double
+    , stratum :: Int
+    , nEvents :: Int
+    }
+    deriving (Show)
 
 data TTEData = TTEData
-  { time :: VS.Vector Double
-  , eventStatus :: V.Vector Delta
-  , xDesignMatrix :: Matrix Double
-  , stratum :: VS.Vector Int
-  , weights :: VS.Vector Double
-  , xProdBeta :: VS.Vector Double
-  , tiesMethod :: CoxPHMethod
-  }
-  deriving Show
+    { time :: VS.Vector Double
+    , eventStatus :: V.Vector Delta
+    , xDesignMatrix :: Matrix Double
+    , stratum :: VS.Vector Int
+    , weights :: VS.Vector Double
+    , xProdBeta :: VS.Vector Double
+    , tiesMethod :: CoxPHMethod
+    }
+    deriving (Show)
 
 data NRTerms = NRTerms
-  { sumWeights :: Double
-  , sumWeightedRisk :: Double
-  , logLikelihood :: Double
-  , score :: VS.Vector Double
-  , xBarUnscaled :: VS.Vector Double
-  , informationTerm1 :: Matrix Double
-  }
-  deriving Show
+    { sumWeights :: Double
+    , sumWeightedRisk :: Double
+    , logLikelihood :: Double
+    , score :: VS.Vector Double
+    , xBarUnscaled :: VS.Vector Double
+    , informationTerm1 :: Matrix Double
+    }
+    deriving (Show)
 
 data NRResults = NRResults
-  { sumLogLikelihood :: Double
-  , score :: VS.Vector Double
-  , informationMatrix :: Matrix Double
-  }
-  deriving Show
+    { sumLogLikelihood :: Double
+    , score :: VS.Vector Double
+    , informationMatrix :: Matrix Double
+    }
+    deriving (Show)
 
 coxPHUpdateNewtonRaphson :: TTEData -> NRResults
 coxPHUpdateNewtonRaphson tteData =
-  let p = cols tteData.xDesignMatrix
-      iterationInfo = IterationInfo
-        { subjectIndex = VS.length tteData.time - 1
-        , time = 0
-        , stratum = 0
-        , nEvents = 0
-        }
-      nrResults = NRResults
-        { sumLogLikelihood = 0
-        , score = VS.replicate p 0
-        , informationMatrix = createEmptyMatrix p
-        }
-      (_, newNRResults) = calcStrata tteData iterationInfo nrResults
-  in  newNRResults
+    let p = cols tteData.xDesignMatrix
+        iterationInfo =
+            IterationInfo
+                { subjectIndex = VS.length tteData.time - 1
+                , time = 0
+                , stratum = 0
+                , nEvents = 0
+                }
+        nrResults =
+            NRResults
+                { sumLogLikelihood = 0
+                , score = VS.replicate p 0
+                , informationMatrix = createEmptyMatrix p
+                }
+        (_, newNRResults) = calcStrata tteData iterationInfo nrResults
+     in newNRResults
 
-calcStrata
-  :: TTEData
-  -> IterationInfo
-  -> NRResults
-  -> (IterationInfo, NRResults)
+calcStrata ::
+    TTEData ->
+    IterationInfo ->
+    NRResults ->
+    (IterationInfo, NRResults)
 calcStrata tteData iterationInfo nrResults
-  -- Case: we've seen all of the subjects. This is the base case
-  | iterationInfo.subjectIndex < 0 = -- TODO: create helper functions for checks
-    (iterationInfo, nrResults)
-  -- Case: compute the remaining strata. We calculate all of the
-  -- relevant terms for the current stratum  and recursively call `calcStrata` to
-  -- conditionally compute the next stratum
-  | otherwise =
-    let p = VS.length nrResults.score
-        initialIterationInfo = resetIterationInfo iterationInfo
-        initialOverallData = createInitialData p
-        initialInformation = createEmptyMatrix p
-        (newIterationInfo, newNRTerms, informationMatrix) =
-          calcTimeBlocks tteData
-                         initialIterationInfo
-                         initialOverallData
-                         initialInformation
-        aggregatedNRResults = aggregateNRResults nrResults
-                                                 newNRTerms
-                                                 informationMatrix
-    in calcStrata tteData newIterationInfo aggregatedNRResults
+    -- Case: we've seen all of the subjects. This is the base case
+    | iterationInfo.subjectIndex < 0 -- TODO: create helper functions for checks
+        =
+        (iterationInfo, nrResults)
+    -- Case: compute the remaining strata. We calculate all of the
+    -- relevant terms for the current stratum  and recursively call `calcStrata` to
+    -- conditionally compute the next stratum
+    | otherwise =
+        let p = VS.length nrResults.score
+            initialIterationInfo = resetIterationInfo iterationInfo
+            initialOverallData = createInitialData p
+            initialInformation = createEmptyMatrix p
+            (newIterationInfo, newNRTerms, informationMatrix) =
+                calcTimeBlocks
+                    tteData
+                    initialIterationInfo
+                    initialOverallData
+                    initialInformation
+            aggregatedNRResults =
+                aggregateNRResults
+                    nrResults
+                    newNRTerms
+                    informationMatrix
+         in calcStrata tteData newIterationInfo aggregatedNRResults
   where
     resetIterationInfo :: IterationInfo -> IterationInfo
     resetIterationInfo iterationInfo =
-      IterationInfo
-        { subjectIndex = iterationInfo.subjectIndex
-        , time = iterationInfo.time
-        , stratum = tteData.stratum VS.! iterationInfo.subjectIndex
-        , nEvents = iterationInfo.nEvents
-        }
-    aggregateNRResults
-      :: NRResults
-      -> NRTerms
-      -> Matrix Double
-      -> NRResults
+        IterationInfo
+            { subjectIndex = iterationInfo.subjectIndex
+            , time = iterationInfo.time
+            , stratum = tteData.stratum VS.! iterationInfo.subjectIndex
+            , nEvents = iterationInfo.nEvents
+            }
+    aggregateNRResults ::
+        NRResults ->
+        NRTerms ->
+        Matrix Double ->
+        NRResults
     aggregateNRResults nrResults overallData informationMatrix =
-      NRResults
-        { sumLogLikelihood = nrResults.sumLogLikelihood
-                             + overallData.logLikelihood
-        , score = add nrResults.score overallData.score
-        , informationMatrix = add nrResults.informationMatrix informationMatrix
-        }
+        NRResults
+            { sumLogLikelihood =
+                nrResults.sumLogLikelihood
+                    + overallData.logLikelihood
+            , score = add nrResults.score overallData.score
+            , informationMatrix = add nrResults.informationMatrix informationMatrix
+            }
 
-calcTimeBlocks
-  :: TTEData
-  -> IterationInfo
-  -> NRTerms
-  -> Matrix Double
-  -> (IterationInfo, NRTerms, Matrix Double)
+calcTimeBlocks ::
+    TTEData ->
+    IterationInfo ->
+    NRTerms ->
+    Matrix Double ->
+    (IterationInfo, NRTerms, Matrix Double)
 calcTimeBlocks tteData iterationInfo overallData informationMatrix
-  -- Case: we've either seen all of the subjects or we've found a subject with a
-  -- different stratum. This is the base case
-  | (iterationInfo.subjectIndex < 0) -- TODO: create helper functions for checks
-      || checkDifferentStrata tteData iterationInfo =
-      (iterationInfo, overallData, informationMatrix)
-  -- Case: the current subject is part of the current stratum (note that it
-  -- could be the first subject in the stratum). We calculate and accumulate all
-  -- of the relevant terms for the subjects within a strata who were censored or
-  -- had an event at the current time, and recursively call
-  -- `calcTimeBlocksSubjects` to conditionally compute the next time block
-  | otherwise =
-      let p = VS.length overallData.score
-          initialTiedData = createInitialData p
-          initialIterationInfo = resetIterationInfo iterationInfo
-          (timeBlockIterationInfo, timeBlockNRTerms, timeBlockTiedData) =
-            calcTimeBlocksSubjects tteData
-                                   initialIterationInfo
-                                   overallData
-                                   initialTiedData
-          aggregateData = case tteData.tiesMethod of
-            Breslow -> computeBreslow
-            Efron   -> computeEfron
-          (newNRTerms, newInformationMatrix) =
-            aggregateData timeBlockIterationInfo
-                          timeBlockNRTerms
-                          timeBlockTiedData
-                          informationMatrix
-      in  calcTimeBlocks tteData
-                         timeBlockIterationInfo
-                         newNRTerms
-                         newInformationMatrix
+    -- Case: we've either seen all of the subjects or we've found a subject with a
+    -- different stratum. This is the base case
+    | (iterationInfo.subjectIndex < 0) -- TODO: create helper functions for checks
+        || checkDifferentStrata tteData iterationInfo =
+        (iterationInfo, overallData, informationMatrix)
+    -- Case: the current subject is part of the current stratum (note that it
+    -- could be the first subject in the stratum). We calculate and accumulate all
+    -- of the relevant terms for the subjects within a strata who were censored or
+    -- had an event at the current time, and recursively call
+    -- `calcTimeBlocksSubjects` to conditionally compute the next time block
+    | otherwise =
+        let p = VS.length overallData.score
+            initialTiedData = createInitialData p
+            initialIterationInfo = resetIterationInfo iterationInfo
+            (timeBlockIterationInfo, timeBlockNRTerms, timeBlockTiedData) =
+                calcTimeBlocksSubjects
+                    tteData
+                    initialIterationInfo
+                    overallData
+                    initialTiedData
+            aggregateData = case tteData.tiesMethod of
+                Breslow -> computeBreslow
+                Efron -> computeEfron
+            (newNRTerms, newInformationMatrix) =
+                aggregateData
+                    timeBlockIterationInfo
+                    timeBlockNRTerms
+                    timeBlockTiedData
+                    informationMatrix
+         in calcTimeBlocks
+                tteData
+                timeBlockIterationInfo
+                newNRTerms
+                newInformationMatrix
   where
     resetIterationInfo :: IterationInfo -> IterationInfo
     resetIterationInfo iterationInfo =
-      IterationInfo
-        { subjectIndex = iterationInfo.subjectIndex
-        , time = tteData.time VS.! iterationInfo.subjectIndex
-        , stratum = iterationInfo.stratum
-        , nEvents = 0
-        }
+        IterationInfo
+            { subjectIndex = iterationInfo.subjectIndex
+            , time = tteData.time VS.! iterationInfo.subjectIndex
+            , stratum = iterationInfo.stratum
+            , nEvents = 0
+            }
 
-computeBreslow
-  :: IterationInfo
-  -> NRTerms
-  -> NRTerms
-  -> Matrix Double
-  -> (NRTerms, Matrix Double)
+computeBreslow ::
+    IterationInfo ->
+    NRTerms ->
+    NRTerms ->
+    Matrix Double ->
+    (NRTerms, Matrix Double)
 computeBreslow iterationInfo overallData tiedData informationMatrix
-  | iterationInfo.nEvents == 0 =
-    let newLogLikelihood = overallData.logLikelihood + tiedData.logLikelihood -- TODO: is there any need to update @overallData@ at all?
-        newNRTerms = (overallData :: NRTerms) { logLikelihood = newLogLikelihood }
-    in  (newNRTerms, informationMatrix)
-  | otherwise =
-    let
-        newSumWeightedRisk = overallData.sumWeightedRisk
-                             + tiedData.sumWeightedRisk
-        newXBarUnscaled = add overallData.xBarUnscaled
-                              tiedData.xBarUnscaled
-        newXBar = scale (1 / newSumWeightedRisk) newXBarUnscaled
-        newInformationTerm1 = add overallData.informationTerm1
-                                  tiedData.informationTerm1
-        newNRTerms = NRTerms
-          { sumWeights = 0
-          , sumWeightedRisk = newSumWeightedRisk
-          , logLikelihood = overallData.logLikelihood
+    | iterationInfo.nEvents == 0 =
+        let newLogLikelihood = overallData.logLikelihood + tiedData.logLikelihood -- TODO: is there any need to update @overallData@ at all?
+            newNRTerms = (overallData :: NRTerms){logLikelihood = newLogLikelihood}
+         in (newNRTerms, informationMatrix)
+    | otherwise =
+        let
+            newSumWeightedRisk =
+                overallData.sumWeightedRisk
+                    + tiedData.sumWeightedRisk
+            newXBarUnscaled =
+                add
+                    overallData.xBarUnscaled
+                    tiedData.xBarUnscaled
+            newXBar = scale (1 / newSumWeightedRisk) newXBarUnscaled
+            newInformationTerm1 =
+                add
+                    overallData.informationTerm1
+                    tiedData.informationTerm1
+            newNRTerms =
+                NRTerms
+                    { sumWeights = 0
+                    , sumWeightedRisk = newSumWeightedRisk
+                    , logLikelihood =
+                        overallData.logLikelihood
                             + tiedData.logLikelihood
                             - (tiedData.sumWeights * log newSumWeightedRisk)
-          , score = add overallData.score
-                        (add tiedData.score
-                             (scale (- tiedData.sumWeights) newXBar))
-          , xBarUnscaled = newXBarUnscaled
-          , informationTerm1 = newInformationTerm1
-          }
-        blockInformation = scale (tiedData.sumWeights / newSumWeightedRisk)
-                                 (add newInformationTerm1
-                                      (scale (- newSumWeightedRisk)
-                                             (outer newXBar newXBar)))
-        newInformationMatrix = add informationMatrix blockInformation
-    in  (newNRTerms, newInformationMatrix)
-
-computeEfron
-  :: IterationInfo
-  -> NRTerms
-  -> NRTerms
-  -> Matrix Double
-  -> (NRTerms, Matrix Double)
-computeEfron iterationInfo overallData tiedData informationMatrix
-  | iterationInfo.nEvents <= 1 =
-    computeBreslow iterationInfo overallData tiedData informationMatrix
-  | otherwise =
-    undefined -- FIXME
-
-calcTimeBlocksSubjects
-  :: TTEData
-  -> IterationInfo
-  -> NRTerms
-  -> NRTerms
-  -> (IterationInfo, NRTerms, NRTerms)
-calcTimeBlocksSubjects tteData iterationInfo overallData tiedData
-  -- Case: we've either seen all of the subjects or we've found a subject with a
-  -- different censoring or event time. This is the base case
-  | (iterationInfo.subjectIndex < 0) -- TODO: create helper functions for checks
-      || checkDifferentStrata tteData iterationInfo
-      || (tteData.time VS.! iterationInfo.subjectIndex) /= iterationInfo.time =
-      (iterationInfo, overallData, tiedData)
-  -- Case: the current subject is part of the current censoring or event tied
-  -- time block (note that it could be the first subject in the block). We
-  -- calculate and accumulate all of the relevant terms for the subject and
-  -- recursively call `calcTimeBlocksSubjects` to conditionally compute the next
-  -- subject in the time block
-  | otherwise =
-      let subjectWeight = tteData.weights VS.! iterationInfo.subjectIndex
-          subjectXProdBeta = tteData.xProdBeta VS.! iterationInfo.subjectIndex
-          subjectWeightedRisk = subjectWeight * exp subjectXProdBeta
-          subjectXRow = tteData.xDesignMatrix LD.! iterationInfo.subjectIndex
-          subjectWeightedXRow = scale subjectWeightedRisk subjectXRow
-          newInformationTerm1 = scale subjectWeightedRisk
-                                      (outer subjectXRow subjectXRow)
-      in  case tteData.eventStatus V.! iterationInfo.subjectIndex of
-            Censored ->
-              let newOverallData = overallData
-                    { sumWeightedRisk = overallData.sumWeightedRisk
-                                        + subjectWeightedRisk
-                    , xBarUnscaled = add overallData.xBarUnscaled
-                                         subjectWeightedXRow
-                    , informationTerm1 = add overallData.informationTerm1
-                                             newInformationTerm1
-                    }
-                  newIterationInfo = iterationInfo
-                    { subjectIndex = iterationInfo.subjectIndex - 1
-                    }
-              in  calcTimeBlocksSubjects
-                    tteData
-                    newIterationInfo
-                    newOverallData
-                    tiedData
-            ObservedEvent ->
-              let newTiedData = tiedData
-                    { sumWeights = tiedData.sumWeights + subjectWeight
-                    , sumWeightedRisk = tiedData.sumWeights
-                                        + subjectWeightedRisk
-                    , logLikelihood = tiedData.logLikelihood
-                                      + (subjectWeight * subjectXProdBeta) -- TODO: split this into logLikelihoodTerm1 and logLikelihoodTerm2?
-                    , score = add tiedData.score (scale subjectWeight subjectXRow)
-                    , xBarUnscaled = add tiedData.xBarUnscaled
-                                         subjectWeightedXRow
+                    , score =
+                        add
+                            overallData.score
+                            ( add
+                                tiedData.score
+                                (scale (-tiedData.sumWeights) newXBar)
+                            )
+                    , xBarUnscaled = newXBarUnscaled
                     , informationTerm1 = newInformationTerm1
                     }
-                  newIterationInfo = iterationInfo
-                    { subjectIndex = iterationInfo.subjectIndex - 1
-                    , nEvents = iterationInfo.nEvents + 1
-                    }
-              in  calcTimeBlocksSubjects
-                    tteData
-                    newIterationInfo
-                    overallData
-                    newTiedData
+            blockInformation =
+                scale
+                    (tiedData.sumWeights / newSumWeightedRisk)
+                    ( add
+                        newInformationTerm1
+                        ( scale
+                            (-newSumWeightedRisk)
+                            (outer newXBar newXBar)
+                        )
+                    )
+            newInformationMatrix = add informationMatrix blockInformation
+         in
+            (newNRTerms, newInformationMatrix)
+
+computeEfron ::
+    IterationInfo ->
+    NRTerms ->
+    NRTerms ->
+    Matrix Double ->
+    (NRTerms, Matrix Double)
+computeEfron iterationInfo overallData tiedData informationMatrix
+    | iterationInfo.nEvents <= 1 =
+        computeBreslow iterationInfo overallData tiedData informationMatrix
+    | otherwise =
+        undefined -- FIXME
+
+calcTimeBlocksSubjects ::
+    TTEData ->
+    IterationInfo ->
+    NRTerms ->
+    NRTerms ->
+    (IterationInfo, NRTerms, NRTerms)
+calcTimeBlocksSubjects tteData iterationInfo overallData tiedData
+    -- Case: we've either seen all of the subjects or we've found a subject with a
+    -- different censoring or event time. This is the base case
+    | (iterationInfo.subjectIndex < 0) -- TODO: create helper functions for checks
+        || checkDifferentStrata tteData iterationInfo
+        || (tteData.time VS.! iterationInfo.subjectIndex) /= iterationInfo.time =
+        (iterationInfo, overallData, tiedData)
+    -- Case: the current subject is part of the current censoring or event tied
+    -- time block (note that it could be the first subject in the block). We
+    -- calculate and accumulate all of the relevant terms for the subject and
+    -- recursively call `calcTimeBlocksSubjects` to conditionally compute the next
+    -- subject in the time block
+    | otherwise =
+        let subjectWeight = tteData.weights VS.! iterationInfo.subjectIndex
+            subjectXProdBeta = tteData.xProdBeta VS.! iterationInfo.subjectIndex
+            subjectWeightedRisk = subjectWeight * exp subjectXProdBeta
+            subjectXRow = tteData.xDesignMatrix LD.! iterationInfo.subjectIndex
+            subjectWeightedXRow = scale subjectWeightedRisk subjectXRow
+            newInformationTerm1 =
+                scale
+                    subjectWeightedRisk
+                    (outer subjectXRow subjectXRow)
+         in case tteData.eventStatus V.! iterationInfo.subjectIndex of
+                Censored ->
+                    let newOverallData =
+                            overallData
+                                { sumWeightedRisk =
+                                    overallData.sumWeightedRisk
+                                        + subjectWeightedRisk
+                                , xBarUnscaled =
+                                    add
+                                        overallData.xBarUnscaled
+                                        subjectWeightedXRow
+                                , informationTerm1 =
+                                    add
+                                        overallData.informationTerm1
+                                        newInformationTerm1
+                                }
+                        newIterationInfo =
+                            iterationInfo
+                                { subjectIndex = iterationInfo.subjectIndex - 1
+                                }
+                     in calcTimeBlocksSubjects
+                            tteData
+                            newIterationInfo
+                            newOverallData
+                            tiedData
+                ObservedEvent ->
+                    let newTiedData =
+                            tiedData
+                                { sumWeights = tiedData.sumWeights + subjectWeight
+                                , sumWeightedRisk =
+                                    tiedData.sumWeights
+                                        + subjectWeightedRisk
+                                , logLikelihood =
+                                    tiedData.logLikelihood
+                                        + (subjectWeight * subjectXProdBeta) -- TODO: split this into logLikelihoodTerm1 and logLikelihoodTerm2?
+                                , score = add tiedData.score (scale subjectWeight subjectXRow)
+                                , xBarUnscaled =
+                                    add
+                                        tiedData.xBarUnscaled
+                                        subjectWeightedXRow
+                                , informationTerm1 = newInformationTerm1
+                                }
+                        newIterationInfo =
+                            iterationInfo
+                                { subjectIndex = iterationInfo.subjectIndex - 1
+                                , nEvents = iterationInfo.nEvents + 1
+                                }
+                     in calcTimeBlocksSubjects
+                            tteData
+                            newIterationInfo
+                            overallData
+                            newTiedData
 
 createInitialData :: Int -> NRTerms
-createInitialData p
-  = NRTerms
-      { sumWeights = 0
-      , sumWeightedRisk = 0
-      , logLikelihood = 0
-      , score = VS.replicate p 0
-      , xBarUnscaled = VS.replicate p 0
-      , informationTerm1 = createEmptyMatrix p
-      }
+createInitialData p =
+    NRTerms
+        { sumWeights = 0
+        , sumWeightedRisk = 0
+        , logLikelihood = 0
+        , score = VS.replicate p 0
+        , xBarUnscaled = VS.replicate p 0
+        , informationTerm1 = createEmptyMatrix p
+        }
 
 createEmptyMatrix :: Int -> Matrix Double
 createEmptyMatrix p = diag (VS.replicate p 0)
 
 checkDifferentStrata :: TTEData -> IterationInfo -> Bool
 checkDifferentStrata tteData iterationInfo =
-  let subjectStratum = tteData.stratum VS.! iterationInfo.subjectIndex
-  in  subjectStratum /= iterationInfo.stratum
+    let subjectStratum = tteData.stratum VS.! iterationInfo.subjectIndex
+     in subjectStratum /= iterationInfo.stratum
 
 -- v1 :: Vector Double
 -- v1 = L.fromList [3, 6]

--- a/src/CoxPH/CoxPHUpdateNewtonRaphson.hs
+++ b/src/CoxPH/CoxPHUpdateNewtonRaphson.hs
@@ -77,24 +77,23 @@ calcStrata tteData iterationInfo nrResults
     -- Case: compute the remaining strata. We calculate all of the
     -- relevant terms for the current stratum  and recursively call `calcStrata` to
     -- conditionally compute the next stratum
-    | otherwise =
-        let p = VS.length nrResults.score
-            initialIterationInfo = resetIterationInfo iterationInfo
-            initialOverallData = createInitialData p
-            initialInformation = createEmptyMatrix p
-            (newIterationInfo, newNRTerms, informationMatrix) =
-                calcTimeBlocks
-                    tteData
-                    initialIterationInfo
-                    initialOverallData
-                    initialInformation
-            aggregatedNRResults =
-                aggregateNRResults
-                    nrResults
-                    newNRTerms
-                    informationMatrix
-         in calcStrata tteData newIterationInfo aggregatedNRResults
+    | otherwise = calcStrata tteData newIterationInfo aggregatedNRResults
   where
+    p = VS.length nrResults.score
+    initialIterationInfo = resetIterationInfo iterationInfo
+    initialOverallData = createInitialData p
+    initialInformation = createEmptyMatrix p
+    (newIterationInfo, newNRTerms, informationMatrix) =
+        calcTimeBlocks
+            tteData
+            initialIterationInfo
+            initialOverallData
+            initialInformation
+    aggregatedNRResults =
+        aggregateNRResults
+            nrResults
+            newNRTerms
+            informationMatrix
     resetIterationInfo :: IterationInfo -> IterationInfo
     resetIterationInfo iterationInfo =
         IterationInfo
@@ -135,30 +134,30 @@ calcTimeBlocks tteData iterationInfo overallData informationMatrix
     -- had an event at the current time, and recursively call
     -- `calcTimeBlocksSubjects` to conditionally compute the next time block
     | otherwise =
-        let p = VS.length overallData.score
-            initialTiedData = createInitialData p
-            initialIterationInfo = resetIterationInfo iterationInfo
-            (timeBlockIterationInfo, timeBlockNRTerms, timeBlockTiedData) =
-                calcTimeBlocksSubjects
-                    tteData
-                    initialIterationInfo
-                    overallData
-                    initialTiedData
-            aggregateData = case tteData.tiesMethod of
-                Breslow -> computeBreslow
-                Efron -> computeEfron
-            (newNRTerms, newInformationMatrix) =
-                aggregateData
-                    timeBlockIterationInfo
-                    timeBlockNRTerms
-                    timeBlockTiedData
-                    informationMatrix
-         in calcTimeBlocks
-                tteData
-                timeBlockIterationInfo
-                newNRTerms
-                newInformationMatrix
+        calcTimeBlocks
+            tteData
+            timeBlockIterationInfo
+            newNRTerms
+            newInformationMatrix
   where
+    p = VS.length overallData.score
+    initialTiedData = createInitialData p
+    initialIterationInfo = resetIterationInfo iterationInfo
+    (timeBlockIterationInfo, timeBlockNRTerms, timeBlockTiedData) =
+        calcTimeBlocksSubjects
+            tteData
+            initialIterationInfo
+            overallData
+            initialTiedData
+    aggregateData = case tteData.tiesMethod of
+        Breslow -> computeBreslow
+        Efron -> computeEfron
+    (newNRTerms, newInformationMatrix) =
+        aggregateData
+            timeBlockIterationInfo
+            timeBlockNRTerms
+            timeBlockTiedData
+            informationMatrix
     resetIterationInfo :: IterationInfo -> IterationInfo
     resetIterationInfo iterationInfo =
         IterationInfo

--- a/src/CoxPH/Data.hs
+++ b/src/CoxPH/Data.hs
@@ -1,25 +1,23 @@
--- |
-
 module CoxPH.Data (
-    CoxPHConvergenceFailure(..)
-  , CoxPHMethod(..)
-  , Delta(..)
-  , LastInStrataIndicator(..)
-  , ScaleCovariateIndicator(..)
-  )
+    CoxPHConvergenceFailure (..),
+    CoxPHMethod (..),
+    Delta (..),
+    LastInStrataIndicator (..),
+    ScaleCovariateIndicator (..),
+)
 where
 
 data Delta = ObservedEvent | Censored
-  deriving Show
+    deriving (Show)
 
 data CoxPHConvergenceFailure = CoxPHConvergenceFailure
-  deriving Show
+    deriving (Show)
 
 data CoxPHMethod = Breslow | Efron
-  deriving Show
+    deriving (Show)
 
 data LastInStrataIndicator = LastInStrataNo | LastInStrataYes
-  deriving Show
+    deriving (Show)
 
 data ScaleCovariateIndicator = ScaleCovariateNo | ScaleCovariateYes
-  deriving Show
+    deriving (Show)

--- a/src/CoxPH/OrderByStrata.hs
+++ b/src/CoxPH/OrderByStrata.hs
@@ -1,34 +1,34 @@
--- |
-
 module CoxPH.OrderByStrata where
 
 import Data.Vector qualified as V
+import Data.Vector.Algorithms.Tim (sortBy)
 import Data.Vector.Storable qualified as VS
-import Data.Vector.Algorithms.Tim ( sortBy )
 
 orderByStrata :: VS.Vector Int -> VS.Vector Double -> VS.Vector Int
 orderByStrata strata times =
-  let orderedTuples = orderByStrataTuples strata times
-  in  VS.convert (V.map extractIndex orderedTuples)
+    let orderedTuples = orderByStrataTuples strata times
+     in VS.convert (V.map extractIndex orderedTuples)
   where
     extractIndex :: (Int, Int, Double) -> Int
     extractIndex (index, _, _) = index
 
-orderByStrataTuples
-  :: VS.Vector Int
-  -> VS.Vector Double
-  -> V.Vector (Int, Int, Double)
+orderByStrataTuples ::
+    VS.Vector Int ->
+    VS.Vector Double ->
+    V.Vector (Int, Int, Double)
 orderByStrataTuples strata times = V.create $ do
-  let n = VS.length strata
-      entriesOrig = V.zip3 (V.iterateN n (+ 1) 0)
-                           (V.convert strata)
-                           (V.convert times)
-  entriesMutable <- V.thaw entriesOrig
-  sortBy compareEntries entriesMutable
-  return entriesMutable
+    let n = VS.length strata
+        entriesOrig =
+            V.zip3
+                (V.iterateN n (+ 1) 0)
+                (V.convert strata)
+                (V.convert times)
+    entriesMutable <- V.thaw entriesOrig
+    sortBy compareEntries entriesMutable
+    return entriesMutable
   where
     compareEntries :: (Int, Int, Double) -> (Int, Int, Double) -> Ordering
     compareEntries (_, stratum1, time1) (_, stratum2, time2)
-      | stratum1 < stratum2 = LT
-      | stratum1 == stratum2 = compare time1 time2
-      | otherwise = GT
+        | stratum1 < stratum2 = LT
+        | stratum1 == stratum2 = compare time1 time2
+        | otherwise = GT


### PR DESCRIPTION
Some small non-substantive edits:

* Ran fourmolu formatter
* Formatted some docstrings, especially for function inputs
* Removed unused multiway if and unused supporting code
* Consolidated let binds into where, in cases where a function used both and it made sense to me to do so

Minor substantive edits that don't change the logic:

* Use traversals to avoid unnecessary computation in some places, where doing so would not change function behavior
* Convert some lazy left folds to strict ones

These changes are broken out into separate commits to make it easier to pick/choose what you want to keep.